### PR TITLE
feat: Display coordinates when selecting point

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -334,10 +334,16 @@
             <mat-icon *ngIf="!focusedItem">add</mat-icon>
         </button>
 
-        <label class="cursor-position" *ngIf="cursorPosition" >
-            {{cursorPosition.x.toFixed(cursorPosition.decimals)}},
-            {{cursorPosition.y.toFixed(cursorPosition.decimals)}}
-        </label>
+        <div class="cursor-position-container" *ngIf="cursorPosition || hoverPosition">
+            <label class="cursor-position selected" *ngIf="cursorPosition">
+                {{cursorPosition.x.toFixed(cursorPosition.decimals)}},
+                {{cursorPosition.y.toFixed(cursorPosition.decimals)}}
+            </label>
+            <label class="cursor-position hovered" *ngIf="hoverPosition">
+                {{hoverPosition.x.toFixed(hoverPosition.decimals)}},
+                {{hoverPosition.y.toFixed(hoverPosition.decimals)}}
+            </label>
+        </div>
 
         <button mat-mini-fab *ngIf="(focusedImage && !cfg.preview && !dragging)"
             color="accent"

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -202,16 +202,28 @@ textarea {
     }
 }
 
-label.cursor-position {
+.cursor-position-container {
     position: absolute;
-    font-size: 1.5em;
-    font-family: monospace;
     bottom:16px;
     left:50%;
     transform: translateX(-50%);
+    display:flex;
+    gap:8px;
+}
+
+label.cursor-position {
+    font-size: 1.5em;
+    font-family: monospace;
     padding:4px 16px;
-    background-color: rgba(255, 255, 255, 0.8);
     color:#111111;
     border-radius: 4px;
     pointer-events: none;
+}
+
+label.cursor-position.selected {
+    background-color: rgba(0, 174, 255, 0.8);
+}
+
+label.cursor-position.hovered {
+    background-color: rgba(255, 0, 0, 0.8);
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -66,11 +66,22 @@ export class AppComponent implements AfterViewInit {
   // Dragged & hovered elements
   draggedPoint: SvgPoint | null = null;
   focusedItem: SvgItem | null = null;
-  hoveredItem: SvgItem | null = null;
+  _hoveredItem: SvgItem | null = null;
+  get hoveredItem(): SvgItem | null { return this._hoveredItem; }
+  set hoveredItem(value: SvgItem | null) {
+    this._hoveredItem = value;
+    if (this._hoveredItem) {
+      const loc = this._hoveredItem.targetLocation();
+      this.hoverPosition = {x: loc.x, y: loc.y, decimals: this.decimals};
+    } else {
+      this.hoverPosition = undefined;
+    }
+  }
   wasCanvasDragged = false;
   draggedIsNew = false;
   dragging = false;
-	cursorPosition?: Point & {decimals?: number};
+  cursorPosition?: Point & {decimals?: number};
+  hoverPosition?: Point & {decimals?: number};
 
   // Images
   images: Image[] = [];

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -514,6 +514,10 @@ export class AppComponent implements AfterViewInit {
           behavior: 'smooth',
           block: 'nearest'
         });
+        const loc = this.focusedItem.targetLocation();
+        this.setCursorPosition({x: loc.x, y: loc.y, decimals: this.decimals});
+      } else {
+        this.setCursorPosition(undefined);
       }
     }
   }

--- a/src/app/canvas/canvas.component.ts
+++ b/src/app/canvas/canvas.component.ts
@@ -238,6 +238,8 @@ export class CanvasComponent implements OnInit, OnChanges, AfterViewInit {
     }
     this.focusedItem = item.itemReference;
     this.draggedPoint = item;
+    // Display the position of the selected point as soon as it is selected
+    this.setCursorPosition({x: item.x, y: item.y, decimals: this.decimals});
   }
 
   startDragCanvas(event: MouseEvent | TouchEvent) {
@@ -259,7 +261,16 @@ export class CanvasComponent implements OnInit, OnChanges, AfterViewInit {
       this.drag(this.draggedEvt);
     }
     this.dragging.emit(false);
-    this.setCursorPosition(undefined);
+    let keptPosition = false;
+    if (this.draggedPoint) {
+      const {x, y} = this.draggedPoint;
+      this.setCursorPosition({x, y, decimals: this.decimals});
+      keptPosition = true;
+    } else if (this.focusedItem) {
+      const loc = this.focusedItem.targetLocation();
+      this.setCursorPosition({x: loc.x, y: loc.y, decimals: this.decimals});
+      keptPosition = true;
+    }
 
     if (!this.draggedPoint && !this.wasCanvasDragged) {
       // unselect action
@@ -274,6 +285,9 @@ export class CanvasComponent implements OnInit, OnChanges, AfterViewInit {
     this.dragWithoutClick = true;
 
     this.draggedImage = null;
+    if (!keptPosition) {
+      this.setCursorPosition(undefined);
+    }
   }
 
   drag(event: MouseEvent | TouchEvent) {


### PR DESCRIPTION
## Summary
- show cursor position when selecting a point
- keep coordinates visible when dragging stops
- update focus handling to display the selected point location

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688608fd5c98832b9f672b7f6d4a9b9e